### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ up as `/mnt/mp3/**.mp3`.
 **Tip:** If your mp3fs mount fails because the underlying filesystem hasn't
 been mounted yet, try adding the `x-systemd.requires-mounts-for=/mnt/music`
 mount option, where `/mnt/music` would be the location of the underlying mount.
+This will wait for the filesystem to be mounted. You might also have to add 
+`nofail` to prevent a missing mount from stopping the boot process.
 
 ## How it Works
 


### PR DESCRIPTION
If the underlying filesystem is required a missing mount might result in a stuck boot process. So add `nofail` to prevent this. 